### PR TITLE
Fix suggested update commands to bower update

### DIFF
--- a/lib/bower-check-updates.js
+++ b/lib/bower-check-updates.js
@@ -128,7 +128,7 @@ function analyzeProjectDependencies(pkgData, pkgFile) {
                     var newPkgData = vm.updatePackageData(pkgData, current, upgraded, latest, options);
                     writePackageFile(pkgFile, newPkgData)
                         .then(function () {
-                            print('Upgraded ' + pkgFile + '\nUpdate the installed dependencies by running ' + chalk.blue('npm update') + '\n');
+                            print('Upgraded ' + pkgFile + '\nUpdate the installed dependencies by running ' + chalk.blue('bower update') + '\n');
                         });
                 }
                         if (options.errorLevel >= 2) {
@@ -213,7 +213,7 @@ function printUpgrades(args) {
                 // adding some space between the unsatisfied to the satisfied
                 print('');
             }
-            print('The following dependenc' + (count === 1 ? 'y is' : 'ies are') + ' satisfied by ' + (count === 1 ? 'its' : 'their') + ' declared version range, but the installed version' + (count === 1 ? ' is' : 's are') + ' behind. You can install the latest version' + (count === 1 ? '' : 's') + ' without modifying your bower.json by using ' + chalk.blue('npm update') + '. If you want to update the dependenc' + (count === 1 ? 'y' : 'ies') + ' in your bower.json anyway, use ' + chalk.blue('bcu --upgradeAll') + '.\n');
+            print('The following dependenc' + (count === 1 ? 'y is' : 'ies are') + ' satisfied by ' + (count === 1 ? 'its' : 'their') + ' declared version range, but the installed version' + (count === 1 ? ' is' : 's are') + ' behind. You can install the latest version' + (count === 1 ? '' : 's') + ' without modifying your bower.json by using ' + chalk.blue('bower update') + '. If you want to update the dependenc' + (count === 1 ? 'y' : 'ies') + ' in your bower.json anyway, use ' + chalk.blue('bcu --upgradeAll') + '.\n');
             print(satisfiedTable.toString());
         }
         if (numUnsatisfied > 0 && args.pkgFile && !args.isUpgrade) {


### PR DESCRIPTION
This is only a cosmetic change to fix output messages which still suggested to run `npm update` commands instead of `bower update`.
